### PR TITLE
Rebase to Alpine 3.17

### DIFF
--- a/root/etc/cont-init.d/98-route2me
+++ b/root/etc/cont-init.d/98-route2me
@@ -1,10 +1,9 @@
 #!/usr/bin/with-contenv bash
 
-echo "**** Installing python and curl ****"
-apt-get update && apt-get install -y --no-install-recommends \
+echo "**** Installing python and pip ****"
+apk --update --no-cache add \
     python3 \
-    python3-pip \
-    curl
+    py3-pip 
 
 echo "**** Installing required python modules ****"
 pip3 install requests-unixsocket

--- a/root/etc/s6-overlay/s6-rc.d/init-mod-route2me-install-deps/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mod-route2me-install-deps/run
@@ -1,9 +1,8 @@
 #!/command/with-contenv bash
 
-echo "**** Adding python and curl as repo dependencies ****"
+echo "**** Adding python and pip as repo dependencies ****"
 echo "python3" >> /mod-repo-packages-to-install.list
-echo "python3-pip" >> /mod-repo-packages-to-install.list
-echo "curl" >> /mod-repo-packages-to-install.list
+echo "py3-pip" >> /mod-repo-packages-to-install.list
 
 echo "**** Adding requests-unixsocket as pip dependency ****"
 echo "requests-unixsocket" >> /mod-pip-packages-to-install.list


### PR DESCRIPTION
When I updated my container, this mod stopped working. A quick look showed that Linuxserver rebased their container on Alpine 3.17 from Ubuntu last month. This changes the command to install python3 and pip so that the rest of the scripts run properly.